### PR TITLE
fix: disable greedy arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,10 @@ cd my-monorepo
 yarn moker use prettier doctoc semantic-release
 
 # create workspaces
-yarn moker add server --template express
-yarn moker add client --template cra
-yarn moker add shared --template lib
-yarn moker add cli --template bandersnatch
+yarn moker add --template express server
+yarn moker add --template cra client
+yarn moker add --template lib shared
+yarn moker add --template bandersnatch cli
 ```
 
 ## Features

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,8 +3,8 @@
   "version": "0.11.2",
   "description": "The moker CLI",
   "repository": "https://github.com/hongaar/moker",
-  "author": "joram@vandenboezem.nl",
   "license": "MIT",
+  "author": "joram@vandenboezem.nl",
   "type": "module",
   "main": "dist/index.js",
   "types": "types/index.d.ts",
@@ -14,11 +14,12 @@
     "types"
   ],
   "scripts": {
-    "start": "node moker.js",
-    "prepublish": "yarn build && cp ../../README.md .",
-    "clean": "rm -rf dist && rm -rf types",
     "build": "yarn clean && tsc",
-    "build:watch": "tsc --watch"
+    "build:watch": "tsc --watch",
+    "clean": "rm -rf dist && rm -rf types",
+    "prepublish": "yarn build && cp ../../README.md .",
+    "start": "node moker.js",
+    "test": "NODE_OPTIONS='--loader=ts-node/esm --no-warnings' node--test test/*.test.ts | NODE_OPTIONS='--loader=ts-node/esm --no-warnings' tap --no-coverage"
   },
   "dependencies": {
     "@mokr/core": "workspace:*",
@@ -28,11 +29,15 @@
   },
   "devDependencies": {
     "@types/node": "18.14.6",
+    "tap": "16.3.4",
+    "test": "3.3.0",
+    "ts-node": "10.9.1",
     "typescript": "4.9.5"
   },
   "moker": {
     "plugins": [
-      "typescript"
+      "typescript",
+      "test"
     ]
   }
 }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -2,7 +2,11 @@ import { assertNodeVersion, assertYarnVersion } from "@mokr/core";
 import { program } from "bandersnatch";
 import * as commands from "./commands/index.js";
 
-const cli = program().prompt("moker > ");
+const cli = program({
+  parserConfiguration: {
+    "greedy-arrays": false,
+  },
+}).prompt("moker > ");
 
 // @ts-ignore
 Object.values(commands).forEach((command) => cli.add(command));

--- a/packages/cli/test/add.test.ts
+++ b/packages/cli/test/add.test.ts
@@ -1,0 +1,80 @@
+import { createDirectory, isDirectory, writePackage } from "@mokr/core";
+import { setFastFail } from "@mokr/core/src/io.js";
+import assert from "node:assert";
+import { temporaryDirectory } from "tempy";
+import test from "test";
+import cli from "../src/cli.js";
+
+/* @ts-expect-error */
+const { beforeEach, before, after, it } = test;
+
+let tempDir: string;
+
+before(() => {
+  setFastFail(true);
+});
+
+after(() => {
+  setFastFail(false);
+});
+
+beforeEach(() => {
+  tempDir = temporaryDirectory();
+});
+
+it("should only run wihtin monorepos", async () => {
+  await assert.rejects(cli.run(`add --cwd ${tempDir} foo`), {
+    name: "Error",
+    message: "Execute this command from within a monorepo",
+  });
+});
+
+it("needs a workspace configuration", async () => {
+  await createDirectory({ directory: `${tempDir}/.git` });
+  await writePackage({
+    directory: tempDir,
+    data: {
+      moker: { scoped: true },
+    },
+  });
+
+  await assert.rejects(cli.run(`add --cwd ${tempDir} foo`), {
+    name: "Error",
+    message: "No workspace configuration found in package.json",
+  });
+});
+
+it("should add a workspace", async () => {
+  const tempDir = temporaryDirectory();
+
+  await createDirectory({ directory: `${tempDir}/.git` });
+  await writePackage({
+    directory: tempDir,
+    data: {
+      workspaces: ["packages/*"],
+      moker: { scoped: true },
+    },
+  });
+
+  await cli.run(`add --cwd ${tempDir} foo`);
+});
+
+it(
+  "should not confuse templates and workspace names",
+  { only: true },
+  async () => {
+    const tempDir = temporaryDirectory();
+
+    await createDirectory({ directory: `${tempDir}/.git` });
+    await writePackage({
+      directory: tempDir,
+      data: {
+        workspaces: ["packages/*"],
+        moker: { scoped: true },
+      },
+    });
+
+    await cli.run(`add --cwd ${tempDir} --template bar foo`);
+    assert(await isDirectory({ directory: `${tempDir}/packages/foo` }));
+  }
+);

--- a/packages/core/src/io.ts
+++ b/packages/core/src/io.ts
@@ -11,6 +11,7 @@ type Log =
       type: "error";
     };
 
+let fastFail = false;
 let messages: Log[];
 let encounteredErrors: boolean;
 
@@ -75,6 +76,10 @@ export function resetState() {
   resetEncounteredErrors();
 }
 
+export function setFastFail(value: boolean) {
+  fastFail = value;
+}
+
 export async function flushLogs() {
   for (const { message, type } of messages) {
     type === "warning"
@@ -98,6 +103,11 @@ export async function task<T>(title: string, callback: () => Promise<T>) {
     spinner.fail();
     logError(error);
     flushLogs();
+
+    if (fastFail) {
+      throw error;
+    }
+
     return [null, error as Error] as const;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5192,6 +5192,9 @@ __metadata:
     "@mokr/templates": "workspace:*"
     "@types/node": 18.14.6
     bandersnatch: 1.11.1
+    tap: 16.3.4
+    test: 3.3.0
+    ts-node: 10.9.1
     typescript: 4.9.5
   bin:
     moker: moker.js


### PR DESCRIPTION
Previously, this would be ambiguous:
```
yarn moker add --template a b
```
Because the `--template` option accepts an array and would be populated with `[a, b]` leaving the `name` argument undefined. This is the default behaviour of `yargs`.

Setting the `parserConfiguration`s `greedy-arrays` to `false` corrects this. To specify multiple templates, use:
```
yarn moker add --template a --template b c
```